### PR TITLE
Fix miner wallet persistence and add miner tests

### DIFF
--- a/backend/app/services/blockchain.py
+++ b/backend/app/services/blockchain.py
@@ -127,12 +127,12 @@ class BlockchainService:
         return new_block
 
     @staticmethod
-    def generate_wallet_address() -> tuple[str, str]:
-        """Generate a new wallet address and private key"""
+    def generate_wallet_address() -> tuple[str, str, str]:
+        """Generate a new wallet address, private key and public key"""
         private_key = secrets.token_hex(32)
         public_key = hashlib.sha256(private_key.encode()).hexdigest()
         address = "RD" + hashlib.sha256(public_key.encode()).hexdigest()[:38]
-        return address, private_key
+        return address, private_key, public_key
 
     @staticmethod
     async def create_transaction(

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/backend/tests/test_miner.py
+++ b/backend/tests/test_miner.py
@@ -1,0 +1,130 @@
+"""Miner integration tests"""
+from datetime import datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.blockchain import Block
+
+
+async def _create_block(
+    db_session: AsyncSession,
+    *,
+    index: int,
+    timestamp: datetime,
+    miner_id: int,
+    miner_address: str,
+    reward: float,
+) -> None:
+    """Helper to insert a block for tests."""
+    block = Block(
+        index=index,
+        timestamp=timestamp,
+        nonce=index,
+        previous_hash=f"prev-{index}",
+        hash=f"hash-{index}-{miner_address}",
+        miner_id=miner_id,
+        miner_address=miner_address,
+        difficulty=4,
+        reward=reward,
+        transaction_count=0,
+        is_valid=True,
+    )
+    db_session.add(block)
+
+
+@pytest.mark.asyncio
+async def test_miner_stats_respects_wallet(
+    client: AsyncClient,
+    auth_headers,
+    db_session: AsyncSession,
+    test_user,
+):
+    """Ensure /api/miner/stats reports only the authenticated user's blocks."""
+    wallet_address = test_user["wallet_address"]
+    user_id = test_user["id"]
+    now = datetime.utcnow()
+
+    await _create_block(
+        db_session,
+        index=1,
+        timestamp=now - timedelta(minutes=5),
+        miner_id=user_id,
+        miner_address=wallet_address,
+        reward=40.0,
+    )
+    await _create_block(
+        db_session,
+        index=2,
+        timestamp=now - timedelta(minutes=1),
+        miner_id=user_id,
+        miner_address=wallet_address,
+        reward=60.0,
+    )
+    await _create_block(
+        db_session,
+        index=3,
+        timestamp=now - timedelta(minutes=2),
+        miner_id=user_id + 100,
+        miner_address="RDOTHER000000000000000000000000000000",  # Different miner
+        reward=75.0,
+    )
+    await db_session.commit()
+
+    response = await client.get("/api/miner/stats", headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["blocks_mined"] == 2
+    assert pytest.approx(data["roadcoins_earned"], rel=1e-3) == 100.0
+    assert data["last_block_time"] is not None
+
+
+@pytest.mark.asyncio
+async def test_miner_blocks_endpoint_returns_only_user_blocks(
+    client: AsyncClient,
+    auth_headers,
+    db_session: AsyncSession,
+    test_user,
+):
+    """Ensure /api/miner/blocks only returns the authenticated user's blocks."""
+    wallet_address = test_user["wallet_address"]
+    user_id = test_user["id"]
+    now = datetime.utcnow()
+
+    await _create_block(
+        db_session,
+        index=5,
+        timestamp=now - timedelta(minutes=10),
+        miner_id=user_id,
+        miner_address=wallet_address,
+        reward=25.0,
+    )
+    await _create_block(
+        db_session,
+        index=6,
+        timestamp=now - timedelta(minutes=3),
+        miner_id=user_id,
+        miner_address=wallet_address,
+        reward=30.0,
+    )
+    await _create_block(
+        db_session,
+        index=7,
+        timestamp=now - timedelta(minutes=1),
+        miner_id=user_id + 200,
+        miner_address="RDANOTHER0000000000000000000000000000",
+        reward=55.0,
+    )
+    await db_session.commit()
+
+    response = await client.get("/api/miner/blocks", headers=auth_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 2
+    returned_indexes = {block["block_index"] for block in data}
+    assert returned_indexes == {5, 6}
+    # Ensure results are sorted by timestamp desc (latest first)
+    assert data[0]["block_index"] == 6


### PR DESCRIPTION
## Summary
- persist generated wallets in the database when a user registers and expose a reusable `get_current_user` dependency
- update the miner stats and blocks queries so they rely on the stored wallet address and handle missing wallets safely
- add pytest configuration updates plus new miner endpoint tests to prevent regressions

## Testing
- `cd backend && pytest tests/test_miner.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198088f20083299c71f4f6710852d9)