### PR TITLE
Allow configuring FastAPI port via environment

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -284,7 +284,7 @@ async def serve_frontend():
    ```bash
    cd backend
    docker-compose up -d  # Start PostgreSQL + Redis
-   python run.py         # Start FastAPI server on :8000
+   python run.py         # Start FastAPI server (defaults to :8000 unless PORT is set)
    ```
 
 2. **Access UI:**

--- a/backend/DEPLOYMENT.md
+++ b/backend/DEPLOYMENT.md
@@ -56,9 +56,10 @@ docker run -d -p 6379:6379 redis:7-alpine
 
 ### 4. Run Application
 ```bash
-python run.py
+# PORT defaults to 8000 if not set
+python run.py                          # respects the PORT env variable
 # Or using uvicorn directly:
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+uvicorn app.main:app --reload --host 0.0.0.0 --port ${PORT:-8000}
 ```
 
 Access the API:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,4 +23,4 @@ COPY . .
 EXPOSE 8000
 
 # Run application
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,7 @@
 # BlackRoad OS Backend Makefile
 
+PORT ?= 8000
+
 .PHONY: help install dev run test clean docker-build docker-up docker-down
 
 help:
@@ -23,7 +25,7 @@ dev:
 	python run.py
 
 run:
-	uvicorn app.main:app --host 0.0.0.0 --port 8000
+	uvicorn app.main:app --host 0.0.0.0 --port $(PORT)
 
 test:
 	pytest -v

--- a/backend/README.md
+++ b/backend/README.md
@@ -76,7 +76,7 @@ nano .env
 docker run -d -p 5432:5432 -e POSTGRES_USER=blackroad -e POSTGRES_PASSWORD=password -e POSTGRES_DB=blackroad_db postgres:15-alpine
 docker run -d -p 6379:6379 redis:7-alpine
 
-# Run the application
+# Run the application (PORT defaults to 8000 if unset)
 python run.py
 ```
 

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,11 +1,15 @@
 """Run the application"""
+import os
+
 import uvicorn
 
+
 if __name__ == "__main__":
+    port = int(os.getenv("PORT", "8000"))
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=port,
         reload=True,
         log_level="info"
     )


### PR DESCRIPTION
## Summary
- allow the FastAPI runner to honor the PORT environment variable so hosted platforms can control the bind port
- update the Dockerfile command and helper scripts/docs to mirror the PORT-aware behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198697e8c0832983e845383cb780fc)