### PR TITLE
Fix VS Code router MIME serialization

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.video import Video, VideoView, VideoLike
 from app.models.file import File, Folder
 from app.models.blockchain import Block, Transaction, Wallet
 from app.models.ai_chat import Conversation, Message
+from app.models.device import Device, DeviceMetric, DeviceLog
 
 __all__ = [
     "User",
@@ -25,4 +26,7 @@ __all__ = [
     "Wallet",
     "Conversation",
     "Message",
+    "Device",
+    "DeviceMetric",
+    "DeviceLog",
 ]

--- a/backend/app/routers/vscode.py
+++ b/backend/app/routers/vscode.py
@@ -59,7 +59,7 @@ async def list_code_files(
                 "name": f.name,
                 "path": f.path,
                 "size": f.size,
-                "mime_type": f.mime_type,
+                "mime_type": f.file_type or None,
                 "folder_id": f.folder_id,
                 "created_at": f.created_at.isoformat(),
                 "updated_at": f.updated_at.isoformat(),
@@ -96,7 +96,7 @@ async def get_file_content(
         "content": "// File content would be loaded here\n// from S3 or file system",
         "metadata": {
             "size": file.size,
-            "mime_type": file.mime_type,
+            "mime_type": file.file_type or None,
             "created_at": file.created_at.isoformat(),
             "updated_at": file.updated_at.isoformat()
         }

--- a/backend/tests/test_vscode_router.py
+++ b/backend/tests/test_vscode_router.py
@@ -1,0 +1,72 @@
+"""Tests for VS Code integration endpoints"""
+from datetime import datetime
+from typing import Optional
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import File
+
+
+async def _create_file(db: AsyncSession, user_id: int, name: str, file_type: Optional[str]) -> File:
+    """Helper to create a file record for tests."""
+    now = datetime.utcnow()
+    file = File(
+        user_id=user_id,
+        name=name,
+        original_name=name,
+        path=f"/workspace/{name}",
+        file_type=file_type,
+        extension=name.split(".")[-1],
+        size=128,
+        storage_key=f"storage/{name}",
+        storage_url=None,
+        checksum="checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(file)
+    await db.commit()
+    await db.refresh(file)
+    return file
+
+
+@pytest.mark.asyncio
+async def test_list_code_files_handles_mime_types(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    test_user: dict,
+):
+    """Ensure /files endpoint returns data even when file_type is missing."""
+    await _create_file(db_session, test_user["id"], "script.py", "text/x-python")
+    await _create_file(db_session, test_user["id"], "README", None)
+
+    response = await client.get("/api/vscode/files", headers=auth_headers)
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["total"] == 2
+    mime_values = {file_info["mime_type"] for file_info in payload["files"]}
+    assert "text/x-python" in mime_values
+    assert None in mime_values
+
+
+@pytest.mark.asyncio
+async def test_get_file_content_returns_metadata(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    test_user: dict,
+):
+    """Ensure the file content endpoint responds with metadata."""
+    file = await _create_file(db_session, test_user["id"], "main.py", "text/x-python")
+
+    response = await client.get(f"/api/vscode/files/{file.id}/content", headers=auth_headers)
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["id"] == file.id
+    assert payload["metadata"]["mime_type"] == "text/x-python"
+    assert payload["metadata"]["size"] == 128


### PR DESCRIPTION
## Summary
- source VS Code file responses from the `file_type` column so missing MIME values no longer raise
- export device models from the shared `app.models` package to prevent import errors during app startup
- add focused tests covering `/api/vscode/files` and `/api/vscode/files/{id}/content` to ensure the endpoints return data even when a file lacks a MIME type

## Testing
- `cd backend && pytest tests/test_vscode_router.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a72d12d88329acbd244ff26875f6)