### PR TITLE
Fix backend dependencies and document new API tags

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,18 +13,20 @@ class Settings(BaseSettings):
     ENVIRONMENT: str = "development"
 
     # Database
-    DATABASE_URL: str
-    DATABASE_ASYNC_URL: str
+    # Provide sensible defaults so local development and tests can run
+    # without requiring environment configuration.
+    DATABASE_URL: str = "sqlite:///./test.db"
+    DATABASE_ASYNC_URL: str = "sqlite+aiosqlite:///./test.db"
 
     # Redis
     REDIS_URL: str = "redis://localhost:6379/0"
 
     # Security
-    SECRET_KEY: str
+    SECRET_KEY: str = "local-dev-secret-key"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
-    WALLET_MASTER_KEY: str
+    WALLET_MASTER_KEY: str = "local-wallet-master-key-32chars-0000"
 
     # CORS
     ALLOWED_ORIGINS: str = "http://localhost:3000,http://localhost:8000"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,18 @@ from app.routers import (
 from app.services.crypto import rotate_plaintext_wallet_keys
 
 
+openapi_tags = [
+    {"name": "railway", "description": "Railway deployment management"},
+    {"name": "vercel", "description": "Vercel project automation"},
+    {"name": "stripe", "description": "Stripe billing integrations"},
+    {"name": "twilio", "description": "Twilio messaging"},
+    {"name": "slack", "description": "Slack workspace automation"},
+    {"name": "discord", "description": "Discord community integrations"},
+    {"name": "sentry", "description": "Sentry monitoring hooks"},
+    {"name": "health", "description": "BlackRoad OS service health"},
+]
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan events"""
@@ -55,7 +67,8 @@ app = FastAPI(
     lifespan=lifespan,
     docs_url="/api/docs",
     redoc_url="/api/redoc",
-    openapi_url="/api/openapi.json"
+    openapi_url="/api/openapi.json",
+    openapi_tags=openapi_tags,
 )
 
 # CORS middleware

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ sqlalchemy==2.0.23
 alembic==1.12.1
 psycopg2-binary==2.9.9
 asyncpg==0.29.0
+aiosqlite==0.19.0
 
 # Authentication & Security
 python-jose[cryptography]==3.3.0
@@ -24,7 +25,7 @@ boto3==1.29.7
 botocore==1.32.7
 
 # Email
-python-email-validator==2.1.0
+email-validator==2.1.0.post1
 emails==0.6.0
 jinja2==3.1.2
 
@@ -54,8 +55,8 @@ httpx==0.25.2
 # Monitoring
 prometheus-client==0.19.0
 
-# CORS
-python-cors==1.0.0
+# CORS (handled by Starlette/FastAPI)
+# Dependency removed because package does not exist on PyPI.
 
 # New API Integrations (Railway, Vercel, Stripe, Twilio, Slack, Discord, Sentry)
 # Note: Most integrations use httpx (already included above)


### PR DESCRIPTION
## Summary
- replace invalid PyPI packages with working dependencies, add aiosqlite support for async SQLite tests, and document the CORS dependency removal in `requirements.txt`
- provide local-friendly defaults for the database and secret settings so the backend can boot in test environments without env vars
- expose tags metadata for the newly added integration routers so the generated OpenAPI schema reflects the expanded surface area

## Testing
- `cd backend && pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919aa0ec5908329ac5934f0ea327790)