### PR TITLE
Add backend test results report

### DIFF
--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,0 +1,18 @@
+# Test Results - Backend
+
+## Environment
+- Python 3.12.12
+- Requirements installed via `pip install -r backend/requirements.txt`
+
+## Commands Executed
+```bash
+cd backend
+pytest
+```
+
+## Outcome
+- 48 tests passed.
+- 29 warnings (mainly deprecated APIs in dependencies).
+- Total runtime: ~34 seconds.
+
+These results confirm that the backend test suite currently succeeds in this environment.


### PR DESCRIPTION
## Summary
- document the backend test environment and commands that were executed
- record the latest pytest results (48 passing tests with warnings noted)

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1610bfa48329be106e89351d68dc)