### PR TITLE
Add brand and domain architecture map

### DIFF
--- a/docs/BRAND_ARCHITECTURE.md
+++ b/docs/BRAND_ARCHITECTURE.md
@@ -1,0 +1,66 @@
+# BlackRoad Brand & Domain Architecture
+
+## Platform Scale Blueprint
+A four-layer model to describe the full product and revenue universe.
+
+### 1. Core OS & Infrastructure (BlackRoad OS / BlackRoad Systems)
+* **Products**: identity graph, agent orchestration, audit & compliance rails, storage, compute, deterministic logging.
+* **Audiences**: enterprises in fintech, regtech, wealth, health, education, government.
+* **Revenue**: platform licensing, consumption-based usage, compliance add-ons, enterprise support.
+
+### 2. Intelligence & Engines (ALICE QI, QI, Quantum)
+* **Products**: ALICE deterministic engine, QI/quant model routers, data stores, risk & anomaly engines, RoadChain audit layer.
+* **Audiences**: heads of AI, risk officers, product teams needing governed agents.
+* **Revenue**: model access fees, risk-scoring APIs, audit trails, premium SLAs, verticalized solutions (portfolio/risk/identity).
+
+### 3. Interfaces & Experiences (Lucidia, Pocket OS, Prism Console)
+* **Products**: Lucidia studio & playgrounds, Prism dashboards, notebooks, Pocket OS personal console.
+* **Audiences**: teams needing premium UI, creators/students via community editions.
+* **Revenue**: pro UI seats, team workspaces, customization packages, education tiers.
+
+### 4. Ecosystem & Commerce (Network, Marketplace, .store/.shop)
+* **Products**: agent/app marketplace, certification programs, training, community network, merch & kits.
+* **Audiences**: developers, integrators, partners, educators, consumers.
+* **Revenue**: marketplace rev share, training & certification, design/build services (Lucidia Studio), commerce (merch, courses, hardware bundles).
+
+## Domain & Trademark Roles
+A concise map for what each doorway is for and how the narrative flows across them.
+
+| Domain / Brand | Primary Role | Core Audience | Signature Calls-to-Action |
+| --- | --- | --- | --- |
+| **blackroad.systems** | Flagship product & corporate site showcasing OS, security, solutions, investor material. | Enterprise buyers, boards, regulators, media. | "Standardize your AI on BlackRoad OS" → demos, architecture, case studies. |
+| **blackroad.network** | Ecosystem & developer hub with docs, SDKs, starter agents, community. | Developers, researchers, integrators, partners. | "Build on BlackRoad" → docs, roadmaps, community join. |
+| **blackroadai.com** | AI product line for agents, orchestration, Prism Console, Pocket OS. | Heads of AI, product leads, innovation teams. | "Spin up compliant agents" → pricing, tiers, SLAs, integrations. |
+| **blackroadqi.com** | Quantitative intelligence line: portfolio/risk engines, compliance dashboards. | Advisors, risk teams, wealth platforms. | "Launch governed analytics" → scenario tools, risk scoring, audit. |
+| **blackroadquantum.com** | Frontier research & lab presence with papers and experiments. | Researchers, universities, advanced practitioners. | "Explore the lab" → research drops, collabs. |
+| **blackroadquantum.net** | Developer APIs and protocol specs for quant/physics-inspired tooling. | Developers building on quant APIs. | "Call the quant APIs" → specs, SDKs. |
+| **blackroadquantum.info** | Education hub with explainers, visualizations, courses. | Students, educators, curious builders. | "Learn the math" → courses, visual explainers. |
+| **blackroadquantum.store / .shop** | Commerce for merch, books, kits, course bundles. | Fans, learners, conference audiences. | "Get the gear" → bundles, limited drops. |
+| **blackroad.me** | Personal identity & Pocket OS portal; BlackRoad ID & billing. | End-users, founders, advisors, students. | "Claim your BlackRoad ID" → personal dashboard, subscriptions. |
+| **lucidia.earth** | Lore & community gateway; interactive experiences and events. | Creators, students, early adopters. | "Meet Lucidia" → playgrounds, challenges, storytelling. |
+| **lucidia.studio** | Creative & services arm; UX/storytelling for BlackRoad builds. | Enterprise design partners, internal prototyping. | "Engage the studio" → retainers, showreel, custom projects. |
+| **aliceqi.com** | Core deterministic engine/protocol powering identity, risk, and QI. | Deep-tech buyers, platform partners. | "Integrate ALICE QI" → engine docs, benchmarks, partnerships. |
+
+## Cross-Domain Narrative (Single Arc)
+1. **Tension**: Modern AI is powerful but chaotic; regulated industries cannot safely scale agents; builders are duct-taping models.
+2. **Vision**: An OS where AI, math, and identity cooperate and are auditable; 1,000 agents behave like a trained team.
+3. **Myth**: BlackRoad = the path; BlackRoad OS = the operating surface; Lucidia = the guide; ALICE QI = the engine; Quantum/QI = the lab; Network = the city; .me = your house.
+4. **Proof**: Demos, docs, case studies, research; every domain offers a "next step" deeper into the funnel.
+5. **Invitation**: Enterprises standardize on BlackRoad OS; developers build on Network; creators world-build with Lucidia; users claim IDs at blackroad.me.
+
+## Mother Manifesto (reuse across investor decks, PR, and about pages)
+BlackRoad builds a deterministic, emotionally aware AI operating system for the regulated world. We fuse identity, math, and orchestration so builders can deploy thousands of agents that are safe by design. Every interaction is traced, every decision is explainable, and every persona honors the human on the other side. From the lab to the boardroom to the classroom, BlackRoad is the path where intelligence, compliance, and creativity move as one.
+
+## Positioning Lines (micro-taglines per domain)
+* **blackroad.systems** – "The compliant AI OS for regulated scale."
+* **blackroad.network** – "Docs, SDKs, and community to build on BlackRoad."
+* **blackroadai.com** – "Launch, govern, and observe compliant agent swarms."
+* **blackroadqi.com** – "Deterministic analytics and risk intelligence for advisors."
+* **blackroadquantum.com** – "Frontier research where math meets AI safety."
+* **blackroadquantum.net** – "Quant APIs and protocols for builders."
+* **blackroadquantum.info** – "Learn the math and models behind safer AI."
+* **blackroadquantum.store / .shop** – "Gear, books, and kits for the BlackRoad quantum crowd."
+* **blackroad.me** – "Your BlackRoad ID, Pocket OS, and personal agents."
+* **lucidia.earth** – "Enter the Lucidia world—learn, play, and create."
+* **lucidia.studio** – "Design and storytelling for the BlackRoad future."
+* **aliceqi.com** – "The deterministic engine that powers BlackRoad intelligence."


### PR DESCRIPTION
## Summary
- add a concise brand and domain architecture guide for BlackRoad and sub-brands
- outline four-layer platform model with product and revenue levers
- include domain roles, cross-domain narrative, manifesto, and positioning lines

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6e90b58083298acafd8ccef7103e)