### PR TITLE
Add single-page brand and product map

### DIFF
--- a/docs/BRAND_PRODUCT_MAP.md
+++ b/docs/BRAND_PRODUCT_MAP.md
@@ -1,0 +1,41 @@
+# BlackRoad Brand & Product Map (Single Page)
+
+**Master line:** *“BlackRoad OS: deterministic, emotionally-aware AI for the people building what’s next.”*
+
+BlackRoad is the operating system for safe, intelligent AI civilizations. Each domain is a doorway into that world, tuned to a specific persona and stage of the journey.
+
+## Brand handles (2–3 words)
+- **BlackRoad OS** — *Civilization Kernel*
+- **BlackRoad Network** — *Builder Gateway*
+- **BlackRoad AI** — *Compliant Workspaces*
+- **ALICE QI** — *Deterministic Brainstem*
+- **BlackRoad QI** — *Numbers That Win*
+- **BlackRoad Quantum** — *Frontier Lab*
+- **BlackRoad.me** — *Pocket OS*
+- **Lucidia Earth** — *Narrative Guide*
+- **Lucidia Studio** — *Futures Design*
+- **BlackRoad Store/Shop** — *Commerce Hub*
+
+## Doorways and jobs-to-be-done
+- **blackroad.systems — “The OS exists.”** Enterprise OS for orchestrating 1,000+ AI agents with audit, identity, and compliance. Jobs: explain vision to execs/investors; map use cases; point to Network/AI/QI.
+- **blackroad.network — “You can build on it.”** Developer gateway with docs, APIs, agent templates, community. Jobs: convert curiosity to prototypes; bridge to AI sandbox and ALICE.
+- **blackroadai.com — “You can use it today.”** Spin up compliant AI workspaces, agents, and consoles on BlackRoad OS. Jobs: sell teams on policy-safe swarms; trials/pricing; upsell to QI packs and identity.
+- **aliceqi.com — “This is the brainstem.”** Deterministic intelligence for identity, risk, and personalized agent behavior. Jobs: impress deep-tech buyers; prove it’s more than a wrapper; route to QI/OS.
+- **blackroadqi.com — “Where numbers win.”** Quantitative intelligence for advisors, risk teams, fintechs. Jobs: show finance/risk workflows; demos/case studies; route to AI console and APIs.
+- **blackroadquantum.com/.net/.info/.store — “Future incubated here.”** Research, models, and experiments at the edge of AI, math, physics. Jobs: signal depth; publish experiments; use .info for teaching, .net for tools, .store for kits/courses.
+- **blackroad.me — “Your place in it.”** BlackRoad ID and Pocket OS for persistent identity/control. Jobs: onboard individuals; login/personalization hub for every property.
+- **lucidia.earth — “Feel it.”** AI storyteller, teacher, and world-builder. Jobs: make people care before they understand; funnel into OS/AI/identity.
+- **lucidia.studio — “Design futures.”** Studio for interfaces, stories, and worlds on BlackRoad OS. Jobs: selective services; R&D lab for new experiences; feeds OS + AI + QI.
+- **blackroad.store/.shop (+ quantum variants) — “Give it a body.”** Courses, certifications, tools, artifacts. Jobs: monetize knowledge/community; commerce backend for all domains.
+
+## Sequencing (phases)
+1. **OS + Network + AI** — Launch 1–3 core products; secure early enterprise logos; drive developer adoption.
+2. **QI + ALICE + Lucidia** — Win vertical traction (wealth/risk/education); ship IP; strengthen brand personality.
+3. **Quantum + Studio + Commerce** — Research/community flywheel; monetize ecosystem (courses, kits, marketplaces).
+
+## Market & revenue surface
+- **Revenue legs:** recurring SaaS (OS, AI consoles, QI tools); usage-based infra (API/compute/data); services (studio/advisory); content & education (courses, cohorts, certs); marketplace rev share (agents/templates/plugins); physical/hybrid (devices, kits, books, merch).
+- **Audiences:** execs/infra buyers (OS/Network); quants & fintech (QI/Alice/Quantum); creators/educators/students (Lucidia/Quantum info); operators & power users (blackroad.me).
+
+## Decision checklist
+For any launch, page, or purchase ask: (1) Which layer is this (OS, network, app, engine, quantum, identity, narrative, commerce)? (2) Which audience (exec, dev, quant, creator, student, operator)? (3) What belief should they leave with (possible, real, for me, safest, exciting)? (4) Where do they jump next (1–2 obvious links into the universe)?


### PR DESCRIPTION
## Summary
- add a single-page brand and product map for the BlackRoad ecosystem
- include concise brand handles for each domain and their jobs-to-be-done
- capture sequencing, revenue surface, and decision checklist

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a701fb26c8329ac7bdba8218088e8)