### PR TITLE
Add Cloudflare API scaffolding with placeholder endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,8 @@ from app.routers import (
     auth, email, social, video, files, blockchain, ai_chat, devices, miner,
     digitalocean, github, huggingface, vscode, games, browser, dashboard,
     railway, vercel, stripe, twilio, slack, discord, sentry, api_health, agents,
-    capture, identity_center, notifications_center, creator, compliance_ops, search
+    capture, identity_center, notifications_center, creator, compliance_ops,
+    search, cloudflare
 )
 from app.services.crypto import rotate_plaintext_wallet_keys
 
@@ -29,6 +30,7 @@ openapi_tags = [
     {"name": "sentry", "description": "Sentry monitoring hooks"},
     {"name": "health", "description": "BlackRoad OS service health"},
     {"name": "agents", "description": "BlackRoad Agent Library - 208 AI agents across 10 categories"},
+    {"name": "cloudflare", "description": "Cloudflare zone, DNS, and Worker scaffolding"},
 ]
 
 
@@ -145,6 +147,7 @@ app.include_router(notifications_center.router)
 app.include_router(creator.router)
 app.include_router(compliance_ops.router)
 app.include_router(search.router)
+app.include_router(cloudflare.router)
 
 # API health monitoring
 app.include_router(api_health.router)

--- a/backend/app/routers/cloudflare.py
+++ b/backend/app/routers/cloudflare.py
@@ -1,0 +1,215 @@
+"""
+Cloudflare Integration API Router
+
+Provides scaffolded endpoints for managing Cloudflare resources including zones,
+DNS records, Workers, and webhooks. These endpoints currently return placeholder
+responses to validate client integrations and will be wired to the real
+Cloudflare API in a future iteration.
+"""
+
+from datetime import datetime
+from typing import Dict, List, Optional
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from app.auth import get_current_user
+from app.models import User
+
+router = APIRouter(prefix="/api/cloudflare", tags=["cloudflare"])
+
+CLOUDFLARE_API_URL = "https://api.cloudflare.com/client/v4"
+CLOUDFLARE_API_TOKEN = os.getenv("CLOUDFLARE_API_TOKEN")
+CLOUDFLARE_ACCOUNT_ID = os.getenv("CLOUDFLARE_ACCOUNT_ID")
+
+
+class CloudflareZone(BaseModel):
+    """Cloudflare zone model"""
+
+    id: str
+    name: str
+    status: str = "active"
+    plan: str = "pro"
+    created_at: datetime
+
+
+class DNSRecordCreate(BaseModel):
+    """DNS record creation payload"""
+
+    type: str = "A"
+    name: str
+    content: str
+    ttl: int = 3600
+    proxied: bool = True
+
+
+class WorkerDeployment(BaseModel):
+    """Worker deployment payload"""
+
+    name: str
+    script: str
+    env_vars: Optional[Dict[str, str]] = None
+
+
+class WebhookRegistration(BaseModel):
+    """Webhook registration payload"""
+
+    name: str
+    destination_url: str
+    events: List[str]
+
+
+def _ensure_configured() -> None:
+    """Validate Cloudflare environment configuration is present"""
+
+    if not CLOUDFLARE_API_TOKEN:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Cloudflare API token not configured",
+        )
+
+    if not CLOUDFLARE_ACCOUNT_ID:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Cloudflare account ID not configured",
+        )
+
+
+@router.get("/zones", response_model=List[CloudflareZone])
+async def list_zones(current_user: User = Depends(get_current_user)) -> List[CloudflareZone]:
+    """Return placeholder zones to validate client integration flows"""
+
+    _ensure_configured()
+
+    now = datetime.utcnow()
+    return [
+        CloudflareZone(
+            id="placeholder-zone-1",
+            name="example.com",
+            created_at=now,
+        ),
+        CloudflareZone(
+            id="placeholder-zone-2",
+            name="blackroad.dev",
+            created_at=now,
+            plan="enterprise",
+        ),
+    ]
+
+
+@router.post("/zones", status_code=status.HTTP_202_ACCEPTED)
+async def create_zone(
+    zone: CloudflareZone, current_user: User = Depends(get_current_user)
+) -> Dict[str, str]:
+    """Accept zone details and return a scaffolded provisioning response"""
+
+    _ensure_configured()
+
+    return {
+        "message": "Zone provisioning queued (placeholder)",
+        "zone_name": zone.name,
+        "zone_id": zone.id,
+        "api_base": CLOUDFLARE_API_URL,
+    }
+
+
+@router.get("/zones/{zone_id}/dns")
+async def list_dns_records(
+    zone_id: str, current_user: User = Depends(get_current_user)
+) -> Dict[str, List[Dict[str, str]]]:
+    """Return placeholder DNS records for a zone"""
+
+    _ensure_configured()
+
+    return {
+        "zone_id": zone_id,
+        "records": [
+            {
+                "id": "placeholder-dns-1",
+                "type": "A",
+                "name": "@",
+                "content": "203.0.113.10",
+                "proxied": True,
+            },
+            {
+                "id": "placeholder-dns-2",
+                "type": "CNAME",
+                "name": "www",
+                "content": "example.com",
+                "proxied": False,
+            },
+        ],
+    }
+
+
+@router.post("/zones/{zone_id}/dns", status_code=status.HTTP_202_ACCEPTED)
+async def create_dns_record(
+    zone_id: str,
+    record: DNSRecordCreate,
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, str]:
+    """Return placeholder acknowledgement for DNS record creation"""
+
+    _ensure_configured()
+
+    return {
+        "message": "DNS record creation queued (placeholder)",
+        "zone_id": zone_id,
+        "record_type": record.type,
+        "record_name": record.name,
+    }
+
+
+@router.get("/workers")
+async def list_workers(current_user: User = Depends(get_current_user)) -> Dict[str, List[Dict[str, str]]]:
+    """Return placeholder Workers bound to the account"""
+
+    _ensure_configured()
+
+    return {
+        "account_id": CLOUDFLARE_ACCOUNT_ID,
+        "workers": [
+            {
+                "name": "edge-cache",
+                "status": "deployed",
+                "last_published": datetime.utcnow().isoformat(),
+            },
+            {
+                "name": "image-resize",
+                "status": "draft",
+                "last_published": None,
+            },
+        ],
+    }
+
+
+@router.post("/workers/deploy", status_code=status.HTTP_202_ACCEPTED)
+async def deploy_worker(
+    deployment: WorkerDeployment, current_user: User = Depends(get_current_user)
+) -> Dict[str, str]:
+    """Return placeholder acknowledgement for Worker deployment"""
+
+    _ensure_configured()
+
+    return {
+        "message": "Worker deployment queued (placeholder)",
+        "worker_name": deployment.name,
+        "script_preview": deployment.script[:50],
+    }
+
+
+@router.post("/webhooks", status_code=status.HTTP_202_ACCEPTED)
+async def register_webhook(
+    webhook: WebhookRegistration, current_user: User = Depends(get_current_user)
+) -> Dict[str, str]:
+    """Return placeholder webhook registration response"""
+
+    _ensure_configured()
+
+    return {
+        "message": "Webhook registration accepted (placeholder)",
+        "webhook_name": webhook.name,
+        "destination": webhook.destination_url,
+        "events": ",".join(webhook.events),
+    }


### PR DESCRIPTION
## Summary
- add a Cloudflare API router with placeholder endpoints for zones, DNS records, workers, and webhooks
- validate Cloudflare configuration up front and return stub data for integration testing
- register the Cloudflare router and tag within the FastAPI application

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a81cae09c8329a88dec506bc02fa6)