### PR TITLE
Add backend test helper and fix compliance event metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ the validation and deploy jobs keep pointing at the same file.
 - **Manual check** – run `python scripts/railway/validate_env_template.py`
   locally to get the same assurance before pushing.
 
+## Testing
+
+Backend tests run against an isolated SQLite database by default. A helper
+script bootstraps a virtual environment, installs dependencies, and executes
+pytest with sensible defaults for local development.
+
+```bash
+# From the repo root
+bash scripts/run_backend_tests.sh
+```
+
+The script exports `ENVIRONMENT=testing`, points `TEST_DATABASE_URL` to a local
+`test.db` SQLite file (override it to point at Postgres if needed), and sets
+`ALLOWED_ORIGINS` so CORS validation passes during the suite. To rerun tests
+inside the prepared environment manually:
+
+```bash
+cd backend
+source .venv-tests/bin/activate
+pytest -v --maxfail=1
+```
+
 ## Architecture
 
 ### Single-Page Application

--- a/backend/app/models/compliance_event.py
+++ b/backend/app/models/compliance_event.py
@@ -13,7 +13,7 @@ class ComplianceEvent(Base):
     actor = Column(String(255))
     action = Column(String(255))
     resource = Column(String(255))
-    metadata = Column(JSON, default=dict)
+    event_metadata = Column("metadata", JSON, default=dict)
     severity = Column(String(50), default="info")
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/routers/compliance_ops.py
+++ b/backend/app/routers/compliance_ops.py
@@ -3,7 +3,7 @@ from typing import List
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.auth import get_current_active_user
 from app.database import get_db
@@ -19,10 +19,11 @@ class ComplianceEventResponse(BaseModel):
     action: str
     resource: str
     severity: str
-    metadata: dict | None = None
+    metadata: dict | None = Field(default=None, alias="event_metadata")
     timestamp: str | None = None
 
     class Config:
+        populate_by_name = True
         from_attributes = True
 
 

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Automated helper to install backend test dependencies and execute pytest
+# using a lightweight SQLite database. This is intended for local development
+# and CI smoke checks.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+VENV_DIR="$BACKEND_DIR/.venv-tests"
+
+cd "$BACKEND_DIR"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  python -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+export TEST_DATABASE_URL="${TEST_DATABASE_URL:-sqlite+aiosqlite:///./test.db}"
+export ENVIRONMENT="${ENVIRONMENT:-testing}"
+export ALLOWED_ORIGINS="${ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:8000}"
+
+pytest -v --maxfail=1


### PR DESCRIPTION
## Summary
- add a helper script and README guidance for running backend tests with a local SQLite database
- rename the compliance event metadata attribute to avoid SQLAlchemy reserved name conflicts while keeping the API payload shape stable
- update the compliance response model configuration to support the renamed attribute

## Testing
- bash scripts/run_backend_tests.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aaf1adf64832996ef8f100f10af35)