### PR TITLE
Investigate HTTPS configuration for subdomains

### DIFF
--- a/ops/domains.yaml
+++ b/ops/domains.yaml
@@ -26,7 +26,7 @@ domains:
     mode: "dns"
     record:
       type: "CNAME"
-      value: "YOUR-PROD-RAILWAY-APP.up.railway.app"  # replace with your Railway host
+      value: "blackroad-operating-system-production.up.railway.app"
 
   - name: "blackroad.ai"
     type: "root"


### PR DESCRIPTION
Replace placeholder "YOUR-PROD-RAILWAY-APP.up.railway.app" with the actual Railway production domain "blackroad-operating-system-production.up.railway.app".

This fixes the issue where https://os.blackroad.systems was not receiving updates from new deployments.