### PR TITLE
Add service health configuration for Prism Console

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,6 +36,11 @@ class Settings(BaseSettings):
     def allowed_origins_list(self) -> List[str]:
         return [origin.strip() for origin in self.ALLOWED_ORIGINS.split(",")]
 
+    # Prism / Status page targets
+    PRISM_CORE_API_URL: str = ""
+    PRISM_PUBLIC_API_URL: str = ""
+    PRISM_CONSOLE_URL: str = ""
+
     # AWS S3
     AWS_ACCESS_KEY_ID: str = ""
     AWS_SECRET_ACCESS_KEY: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
 import time
+from datetime import datetime, timezone
 import os
 
 from app.config import settings
@@ -225,8 +226,22 @@ else:
 async def health_check():
     """Health check endpoint"""
     return {
+        "service": "core-api",
         "status": "healthy",
-        "timestamp": time.time()
+        "environment": settings.ENVIRONMENT,
+        "version": settings.APP_VERSION,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+
+
+@app.get("/version")
+async def version():
+    """Service version endpoint"""
+    return {
+        "service": "core-api",
+        "version": settings.APP_VERSION,
+        "environment": settings.ENVIRONMENT,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 

--- a/backend/app/routers/prism_static.py
+++ b/backend/app/routers/prism_static.py
@@ -64,6 +64,15 @@ async def serve_prism_console():
     return FileResponse(prism_index)
 
 
+@router.get("/prism/health")
+async def prism_health():
+    """Health endpoint for Prism Console assets."""
+    return {
+        "service": "prism-console",
+        "status": "healthy",
+    }
+
+
 @router.get("/prism/{file_path:path}")
 async def serve_prism_static_files(file_path: str):
     """

--- a/prism-console/index.html
+++ b/prism-console/index.html
@@ -58,6 +58,25 @@
                 </div>
 
                 <div class="section">
+                    <h3>Service Health</h3>
+                    <table class="data-table">
+                        <thead>
+                            <tr>
+                                <th>Service</th>
+                                <th>Status</th>
+                                <th>Version</th>
+                                <th>Endpoint</th>
+                            </tr>
+                        </thead>
+                        <tbody id="service-health-body">
+                            <tr>
+                                <td colspan="4" class="empty-state">Waiting for health checks...</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="section">
                     <h3>Quick Actions</h3>
                     <div class="button-group">
                         <button class="action-button" onclick="refreshDashboard()">Refresh Dashboard</button>

--- a/prism-console/static/css/prism.css
+++ b/prism-console/static/css/prism.css
@@ -216,6 +216,28 @@ body {
     border-bottom: 1px solid var(--prism-border);
 }
 
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.status-badge.healthy {
+    background: rgba(16, 185, 129, 0.12);
+    color: #10b981;
+    border: 1px solid rgba(16, 185, 129, 0.35);
+}
+
+.status-badge.unhealthy {
+    background: rgba(239, 68, 68, 0.12);
+    color: #ef4444;
+    border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
 .empty-state {
     text-align: center;
     color: var(--prism-text-muted);


### PR DESCRIPTION
## Summary
- add configurable service URLs for Prism health checks and expose them through the system API
- enhance health/version endpoints with timezone-aware metadata and a Prism Console health route
- upgrade the Prism Console dashboard to show live service health and versions from backend configuration

## Testing
- python -m compileall backend/app prism-console/static/js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3e0549788329883b9268853ca5b4)