### PR TITLE
Use timezone-aware build timestamp in version endpoint

### DIFF
--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -1,7 +1,7 @@
 """System endpoints for core OS operations"""
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from datetime import datetime
+from datetime import UTC, datetime
 import os
 
 from app.config import settings
@@ -22,7 +22,7 @@ async def get_version():
 
     return {
         "version": settings.APP_VERSION,
-        "build_time": datetime.utcnow().isoformat(),
+        "build_time": datetime.now(UTC).isoformat(),
         "env": settings.ENVIRONMENT,
         "git_sha": git_sha[:8] if len(git_sha) > 8 else git_sha,
         "app_name": settings.APP_NAME,


### PR DESCRIPTION
## Summary
- make the system version endpoint use a timezone-aware UTC timestamp for build_time

## Testing
- pytest backend/tests/test_system.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3ee33cdc8329aee7d740ec5dc6e5)