### PR TITLE
Add Cloudflare keys to env template validation

### DIFF
--- a/scripts/railway/validate_env_template.py
+++ b/scripts/railway/validate_env_template.py
@@ -54,6 +54,10 @@ EXTRA_REQUIRED_KEYS: Set[str] = {
     "NEXTAUTH_SECRET",
     "NODE_ENV",
     "PYTHON_ENV",
+    # Cloudflare details used by infrastructure automation and DNS routes
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_ZONE_ID",
+    "CLOUDFLARE_EMAIL",
 }
 
 SENSITIVE_KEYS: Set[str] = {


### PR DESCRIPTION
## Summary
- treat Cloudflare account, zone, and email identifiers as expected keys in the Railway env template validator
- keep env validation output clean when .env.example includes Cloudflare deployment fields

## Testing
- python scripts/railway/validate_env_template.py --skip-config

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e7b77a2248329b5a5562aa1471db4)