### PR TITLE
Add centralized services registry

### DIFF
--- a/deploy/services.json
+++ b/deploy/services.json
@@ -1,0 +1,74 @@
+{
+  "services": [
+    {
+      "id": "core",
+      "name": "Core API",
+      "repo": "BlackRoad-OS/blackroad-os-core",
+      "kind": "backend",
+      "railwayProjectId": "602cb63b-6c98-4032-9362-64b7a90f7d94",
+      "environment": "production",
+      "url": "https://core.blackroad.systems",
+      "healthPath": "/health"
+    },
+    {
+      "id": "api",
+      "name": "Public API Gateway",
+      "repo": "BlackRoad-OS/blackroad-os-api",
+      "kind": "backend",
+      "railwayProjectId": "f9116368-9135-418c-9050-39496aa9079a",
+      "environment": "production",
+      "url": "https://api.blackroad.systems",
+      "healthPath": "/health"
+    },
+    {
+      "id": "operator",
+      "name": "Operator Workers",
+      "repo": "BlackRoad-OS/blackroad-os-operator",
+      "kind": "backend",
+      "railwayProjectId": "ee43ab16-44c3-4be6-b6cf-e5faf380f709",
+      "environment": "production",
+      "url": "https://operator.blackroad.systems",
+      "healthPath": "/health"
+    },
+    {
+      "id": "agents",
+      "name": "Agents Service",
+      "repo": "BlackRoad-OS/blackroad-os-agents",
+      "kind": "backend",
+      "railwayProjectId": "PLACEHOLDER_AGENTS_PROJECT",
+      "environment": "production",
+      "url": "https://agents.blackroad.systems",
+      "healthPath": "/health"
+    },
+    {
+      "id": "console",
+      "name": "Prism Console",
+      "repo": "BlackRoad-OS/blackroad-os-prism-console",
+      "kind": "frontend",
+      "railwayProjectId": "70ce678e-1e2f-4734-9024-6fb32ee5c8eb",
+      "environment": "production",
+      "url": "https://console.blackroad.systems",
+      "healthPath": "/health"
+    },
+    {
+      "id": "web",
+      "name": "Public Web",
+      "repo": "BlackRoad-OS/blackroad-os-web",
+      "kind": "frontend",
+      "railwayProjectId": "ee43ab16-44c3-4be6-b6cf-e5faf380f709",
+      "environment": "production",
+      "url": "https://blackroad.systems",
+      "healthPath": "/health"
+    },
+    {
+      "id": "docs",
+      "name": "Docs",
+      "repo": "BlackRoad-OS/blackroad-os-docs",
+      "kind": "frontend",
+      "railwayProjectId": "a4efb8cd-0d67-4b19-a7f3-b6dbcedf2079",
+      "environment": "production",
+      "url": "https://docs.blackroad.systems",
+      "healthPath": "/health"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a deploy/services.json atlas mapping BlackRoad services to repos, URLs, and Railway project IDs

## Testing
- not run (not needed for data addition)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4e80d198832995055448d3c04d0b)