### PR TITLE
Clarify deployment targets and UI entrypoint

### DIFF
--- a/DEPLOYMENT_ARCHITECTURE.md
+++ b/DEPLOYMENT_ARCHITECTURE.md
@@ -94,6 +94,11 @@ This document establishes the canonical deployment model to prevent misconfigura
    - It's not designed to run as a service
    - It will break everything
 
+4. **Never host the legacy `blackroad-os` bundle**
+   - The only supported UI lives in `backend/static/index.html`
+   - Serve it through the FastAPI backend or the `blackroad-os-web` satellite
+   - Do not push the monorepo or `/blackroad-os` assets directly to Pages/GoDaddy
+
 ### ✅ ALWAYS DO THIS
 
 1. **Deploy ONLY satellite repos to Railway**

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ All BlackRoad services, apps, and docs now live in this monorepo and sync out au
 > - ❌ **DO NOT** add `BlackRoad-Operating-System` to Railway as a service
 > - ❌ **DO NOT** deploy this monorepo to any production environment
 > - ❌ **DO NOT** reference this repo in service configurations or env vars
+> - ❌ **DO NOT** publish the legacy `blackroad-os` static bundle; only ship the
+>   canonical UI that lives under `backend/static/`
 >
 > **Deploy ONLY the satellite repositories:**
 > - `blackroad-os-core` (Core API)
@@ -56,6 +58,8 @@ All BlackRoad services, apps, and docs now live in this monorepo and sync out au
 > - `blackroad-os-prism-console` (Status Console)
 > - `blackroad-os-docs` (Documentation)
 > - `blackroad-os-web` (Public Website)
+> - **Never deploy `BlackRoad-Operating-System` itself** — Railway, GoDaddy, and
+>   Pages should point at the satellites above, not this repo
 >
 > **This repo is the source of truth for code**, but **satellites are the deployable services**.
 >


### PR DESCRIPTION
## Summary
- reinforce that deployments must target the satellite repositories and not the monorepo
- document that the supported UI entry point is backend/static/index.html and to avoid the legacy blackroad-os bundle

## Testing
- Not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f92be93288329867444ec95e4bb7f)