### PR TITLE
Expand domain registry for Cloudflare-managed domains

### DIFF
--- a/ops/domains.yaml
+++ b/ops/domains.yaml
@@ -6,35 +6,83 @@
 #   - dns: set DNS records (CNAME or A)
 
 domains:
-  # Primary domain: blackroad.systems serves the main application
+  # === blackroad.systems (primary corporate + OS surface) ===
   - name: "blackroad.systems"
     type: "root"
-    provider: "godaddy"
+    provider: "cloudflare"
     mode: "dns"
     record:
       type: "CNAME"
-      value: "YOUR-PROD-RAILWAY-APP.up.railway.app"  # replace with your Railway host
-    notes: "Main flagship corporate site - serves BlackRoad OS application directly"
+      value: "cname.vercel-dns.com"  # Production corporate site on Vercel
+    notes: "Flagship corporate site served by blackroad.io deployment"
+    healthcheck: true
 
-  # www subdomain redirects to apex domain
   - name: "www.blackroad.systems"
     type: "subdomain"
-    provider: "godaddy"
-    mode: "forward"
-    forward_to: "https://blackroad.systems"
-    forwarding_type: 301
-    notes: "Redirects to canonical apex domain"
-
-  # os subdomain can be used as an alias
-  - name: "os.blackroad.systems"
-    type: "subdomain"
-    provider: "godaddy"
+    provider: "cloudflare"
     mode: "dns"
     record:
       type: "CNAME"
-      value: "blackroad-os-core-production.up.railway.app"  # Core API satellite service
-    notes: "Alternative subdomain alias for the OS application - points to Core API satellite"
+      value: "blackroad.systems"  # www redirect handled at Vercel/Cloudflare
+    notes: "Redirects to apex domain"
 
+  - name: "os.blackroad.systems"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad-os-production.up.railway.app"
+    notes: "Primary OS interface (blackroad-os-core)"
+    healthcheck: true
+
+  - name: "api.blackroad.systems"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad-api-production.up.railway.app"
+    notes: "API gateway"
+    healthcheck: true
+
+  - name: "prism.blackroad.systems"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad-prism-console.vercel.app"
+    notes: "Prism Console"
+
+  - name: "operator.blackroad.systems"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad-operator.up.railway.app"
+    notes: "Internal operator service (proxy off)"
+
+  - name: "lucidia.blackroad.systems"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "lucidia-api.up.railway.app"
+    notes: "Lucidia API"
+
+  - name: "docs.blackroad.systems"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackboxprogramming.github.io"
+    notes: "Developer docs"
+
+  # === blackroad.ai (alias to OS) ===
   - name: "blackroad.ai"
     type: "root"
     provider: "cloudflare"
@@ -42,22 +90,244 @@ domains:
     record:
       type: "CNAME"
       value: "os.blackroad.systems"
+    notes: "Alias to OS"
 
+  - name: "www.blackroad.ai"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.ai"
+    notes: "www redirect"
+
+  # === blackroad.network (developer portal alias) ===
+  - name: "blackroad.network"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackboxprogramming.github.io"
+    notes: "Developer docs alias"
+    healthcheck: true
+
+  - name: "www.blackroad.network"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.network"
+    notes: "www redirect"
+
+  - name: "api.blackroad.network"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad-api-production.up.railway.app"
+    notes: "Developer API"
+
+  # === blackroad.me (identity alias) ===
+  - name: "blackroad.me"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.systems"
+    notes: "Personal identity alias"
+
+  - name: "www.blackroad.me"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.me"
+    notes: "www redirect"
+
+  # === aliceqi.com (ALICE QI engine) ===
+  - name: "aliceqi.com"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "lucidia-api.up.railway.app"
+    notes: "ALICE QI endpoint"
+
+  - name: "www.aliceqi.com"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "aliceqi.com"
+    notes: "www redirect"
+
+  # === blackroadqi.com (QI module) ===
+  - name: "blackroadqi.com"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad-api-production.up.railway.app"
+    notes: "Financial intelligence module"
+
+  - name: "www.blackroadqi.com"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroadqi.com"
+    notes: "www redirect"
+
+  # === lucidia.earth (narrative experiences) ===
+  - name: "lucidia.earth"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "lucidia-api.up.railway.app"
+    notes: "Narrative experiences"
+
+  - name: "www.lucidia.earth"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "lucidia.earth"
+    notes: "www redirect"
+
+  # === blackroadquantum.com (placeholder redirect to main) ===
+  - name: "blackroadquantum.com"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.systems"
+    notes: "Placeholder until quantum hub is live"
+
+  - name: "www.blackroadquantum.com"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroadquantum.com"
+    notes: "www redirect"
+
+  # === roadwallet.com (wallet alias) ===
   - name: "roadwallet.com"
     type: "root"
     provider: "cloudflare"
     mode: "dns"
     record:
       type: "CNAME"
-      value: "os.blackroad.systems"
+      value: "blackroad.systems"
+    notes: "Wallet alias placeholder"
 
+  - name: "www.roadwallet.com"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "roadwallet.com"
+    notes: "www redirect"
+
+  # === aliceos.io (legacy alias) ===
   - name: "aliceos.io"
     type: "root"
     provider: "cloudflare"
     mode: "dns"
     record:
       type: "CNAME"
-      value: "os.blackroad.systems"
+      value: "blackroad.systems"
+    notes: "Legacy OS alias"
+
+  - name: "www.aliceos.io"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "aliceos.io"
+    notes: "www redirect"
+
+  # === Quantum family placeholders ===
+  - name: "blackroadquantum.net"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.systems"
+    notes: "Hold with 301/alias to main site"
+
+  - name: "blackroadquantum.info"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.systems"
+    notes: "Hold with 301/alias to main site"
+
+  - name: "blackroadquantum.store"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.systems"
+    notes: "Hold with 301/alias to main site"
+
+  # === lucidia.studio (creative stack) ===
+  - name: "lucidia.studio"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "lucidia-api.up.railway.app"
+    notes: "Creative production endpoint"
+
+  - name: "www.lucidia.studio"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "lucidia.studio"
+    notes: "www redirect"
+
+  # === blackroad.store (commerce placeholder) ===
+  - name: "blackroad.store"
+    type: "root"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.systems"
+    notes: "Commerce placeholder forwarding to main site"
+
+  - name: "www.blackroad.store"
+    type: "subdomain"
+    provider: "cloudflare"
+    mode: "dns"
+    record:
+      type: "CNAME"
+      value: "blackroad.store"
+    notes: "www redirect"
 
 # Add additional domains or subdomains here following the same pattern.
 # By default you can set mode: "dns" with a CNAME pointing to os.blackroad.systems,


### PR DESCRIPTION
## Summary
- update ops/domains.yaml to list all BlackRoad domains and subdomains with Cloudflare-managed DNS targets
- point blackroad.systems apex to the Vercel corporate site and map key subdomains to their Railway/Vercel services with healthcheck flags
- add aliases and placeholders for secondary and tertiary domains to converge DNS in one registry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f97383dd08329872553921e433350)