### PR TITLE
Fix sqlite compatibility for cognition models

### DIFF
--- a/backend/app/routers/cece.py
+++ b/backend/app/routers/cece.py
@@ -242,7 +242,7 @@ async def run_cognition(
                         input_context=request.input,
                         output=str(step_value),
                         confidence_score=pipeline.get('confidence', 0.0),
-                        metadata={'mode': request.mode}
+                        trace_metadata={'mode': request.mode}
                     )
                     db.add(trace)
                     step_number += 1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,11 +3,17 @@ import pytest
 import pytest_asyncio
 import asyncio
 import os
+import sys
+from pathlib import Path
 from typing import AsyncGenerator
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
 
 from app.main import app
 from app.database import get_db, Base


### PR DESCRIPTION
## Summary
- add GUID and JSONB compatibility types so cognition models work on SQLite
- update cognition metadata fields and cece router usage to match renamed columns
- make backend tests import the FastAPI app reliably from the repository root

## Testing
- pytest backend/tests -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f963743d4832990f18a914fd6d47a)