### PR TITLE
Expand default CORS origins for Railway deployments

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,7 +30,19 @@ class Settings(BaseSettings):
 
     # CORS
     # Include production domains by default to ensure Railway deployments work
-    ALLOWED_ORIGINS: str = "https://blackroad.systems,https://app.blackroad.systems,https://www.blackroad.systems,https://os.blackroad.systems,https://blackroad-operating-system-production.up.railway.app,http://localhost:3000,http://localhost:8000"
+    ALLOWED_ORIGINS: str = (
+        "https://blackroad.systems,"
+        "https://app.blackroad.systems,"
+        "https://www.blackroad.systems,"
+        "https://os.blackroad.systems,"
+        "https://blackroad-operating-system-production.up.railway.app,"
+        "https://fastapi-production-3753.up.railway.app,"
+        "https://hello-world-production-789d.up.railway.app,"
+        "https://nodejs-production-2a66.up.railway.app,"
+        "https://serene-success-production.up.railway.app,"
+        "http://localhost:3000,"
+        "http://localhost:8000"
+    )
 
     @property
     def allowed_origins_list(self) -> List[str]:


### PR DESCRIPTION
## Summary
- add new Railway deployment URLs to the default CORS allowed origins list

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9a1b45dc83299df6997d6560847f)