### PR TITLE
Fix QLM alignment inference and event range queries

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure repository root is on sys.path so qlm_lab can be imported during tests
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- ensure agent completion events inherit related intent when not explicitly provided so alignment calculations work
- adjust time range queries to include just-recorded events and keep qlm_lab imports available in tests

## Testing
- pytest tests/test_qlm_core.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9ad046b08329958955e48d66e3ba)