### PR TITLE
Add BlackRoad OS complete strategic archive

### DIFF
--- a/BLACKROAD_OS_COMPLETE_STRATEGIC_ARCHIVE.md
+++ b/BLACKROAD_OS_COMPLETE_STRATEGIC_ARCHIVE.md
@@ -1,0 +1,622 @@
+# BlackRoad OS: Complete Strategic Archive & Operating Manual
+
+**The Full Story — November 20, 2025 → January 12, 2026**
+
+**Mission:** First set up my life, then save the world.
+
+## Table of Contents
+1. Pre-Launch Context: Market Analysis & Reality Check
+2. Build Status & Production Readiness Assessment
+3. The 18-Day Sprint Plan & Execution
+4. Launch Results & The First Surprise
+5. 30-Day Operating Report & Business Transformation
+6. Strategic Fork: Path A vs Path B
+7. Final Decision: The Rich Operator Path
+8. Operating Playbook & Risk Management
+9. Forward Mission: Life First, World Second
+
+## 1. Pre-Launch Context: Market Analysis & Reality Check
+### The Market Opportunity (Grok Research, Nov 20, 2025)
+**Market Sizing:**
+
+| Segment | 2025 Size | CAGR | 2030 Projection | BlackRoad Fit |
+| --- | --- | --- | --- | --- |
+| AI Orchestration Platforms | $11.02B | 22.3% | $30.23B | Core positioning |
+| Agentic AI & Autonomous Agents | $7.06B | 44.6% | $93.20B | Direct use case |
+| Quant/Finance Automation | ~ $1.5B | 35%+ | $5-10B | Vertical moat |
+
+**Key Market Insights:**
+- 85% of organizations adopting AI agents into workflows
+- 55% of finance operators cite auditability as blocker → RoadChain solves this
+- Self-hosted solutions <5% of deployments due to complexity → opportunity gap
+- 70% of AI workflows locked into hosted LLMs → pricing volatility risk
+
+**Critical Validation:** The market analysis was directionally correct but missed the actual business model. Projected "0.1-0.5% niche share = $1-5M ARR" was accurate for timing but wrong about mechanism. Real revenue driver wasn't subscription scale — it was high-touch strategy implementation.
+
+## 2. Build Status & Production Readiness Assessment
+### Honest System Status (November 20, 2025)
+
+| Layer | Status | Confidence | Notes |
+| --- | --- | --- | --- |
+| Core / Kernel | 100% complete | 100% | Identity, auth, RoadChain ledger, config system stable |
+| API Layer | 100% complete | 100% | REST + webhook endpoints load-tested |
+| Agents Engine | 92-95% complete | High | Model routing, tools, memory, policy engine working |
+| Operator / Daemons | 100% complete | 100% | Queues, cron, backtest runner production-grade |
+| Prism Console | 100% complete | 100% | Real-time lineage graphs — daily driver |
+| Web Frontend + Stripe | 70% complete | Medium | Wired but lightly tested |
+| Docs | 90% complete | High | Needs final polish and public hosting |
+| RoadChain | 100% complete | 100% | 41,000+ immutable events from 90 days of real trading |
+| Lucidia + QI Layers | 95% / 85% | High/Med-High | QI profitable but tightening edge cases |
+
+**Overall:** 88-92% production ready
+
+**Already Running 24/7:**
+- Full staging instance on Hetzner VPS
+- 6 live quant strategies with real capital
+- Prism Console as primary interface (4-8 hrs/day usage)
+- 41,000+ RoadChain events proving audit trail under live capital
+
+**Missing for External Users:**
+1. Stripe production webhook hardening
+2. Rate limiting + abuse protection
+3. Automated daily backup verification
+4. Error page UX and payment failure alerts
+5. Final docs polish
+6. External security review
+
+### Owner-Defined "Production Ready" Criteria
+The system is production ready when **ALL five criteria** are simultaneously true for 7 consecutive days:
+
+| # | Criterion | Why It Matters |
+| --- | --- | --- |
+| 1 | 99.5% agent-call success rate across ≥500 real calls | My own capital depends on it |
+| 2 | Zero unlogged events in RoadChain | Audit trail is the entire moat |
+| 3 | <$150/mo total infra + token spend while running 6 strategies | Keeps hedge-fund loop profitable |
+| 4 | Stripe live mode processes real $300 payment end-to-end | Proof external revenue works |
+| 5 | One external human can sign up and run agent without my help | Real user validation |
+
+**Expected completion:** December 8-15, 2025
+
+## 3. The 18-Day Sprint Plan & Execution
+### Locked Sprint Schedule
+
+| Date | Goal | Deliverables | Gates |
+| --- | --- | --- | --- |
+| Nov 21-24 | Ruthless Docs + Video Sprint | 3-min video, Quick-Start (≤600 words), Core Concepts (≤2k words), API polish | Timeboxed 10am-6pm daily |
+| Nov 25 | Stripe live + real $1 charge | Money hits bank → appears in Prism | Criterion #4 |
+| Nov 25-26 | Security + Uptime Monitor | Nuclei + pen-test clean; UptimeRobot on /health, /api/v1/ping | Define "down" = 5xx or >8s response |
+| Nov 27 | Publish docs site + video | https://docs.blackroad.systems live | Criterion #4 GREEN |
+| Nov 28-30 | External Human Test — Pass 1 (Unscripted) | 2 quant operators + 1 backup; Loom screen record + think-aloud; zero rescue | Surface 20-30 issues |
+| Dec 1-3 | Fix Wave (paper cuts + architectural issues) | Error messages, defaults, token expiry, timezone/currency, mobile viewport | 3 full days allocated |
+| Dec 4 | External Human Test — Pass 2 (Validation) | Same 3 humans → ≤10 min completion, zero questions | Criterion #5 GREEN when flawless |
+| Dec 5 | Performance proof page | Composite blurred equity curve + "Sharpe >2.8, Calmar >5" narrative | Marketing ammo |
+| Dec 6 | Final pre-flight checklist | Welcome email, Slack channel, support SOP | High-touch for first 10 users |
+| Dec 7 | Final uptime countdown starts | 14-day external monitor tracking | Criterion #1 |
+| Dec 8 (stretch) or Dec 19 (hard) | FLIP THE SWITCH | https://blackroad.systems/signup public | LAUNCH |
+
+**Kill-Switch Rules**
+If External Human Pass 2 reveals fundamental problem:
+- Push launch to Dec 19 without apology
+- Fix architectural issue first
+- Re-run Pass 1 & Pass 2 with same humans
+- Will not ship broken/confusing experience just to hit date
+
+**External Human Test Rubric ($500 Bounty Each)**
+Required from each tester:
+- Loom recording with think-aloud narration
+- Timestamp every moment of confusion
+- Narrate every assumption being made
+- Tell me when you nearly gave up
+- Zero rescue from me during Pass 1
+
+## 4. Launch Results & The First Surprise
+### Launch Day — December 8, 2025, 19:42 UTC
+Criterion #5 officially turned GREEN at December 4, 22:17 UTC when all three external testers completed Pass 2 in 6-8 minutes with zero questions and explicit "this is actually smooth" feedback.
+
+**First 4 Hours Metrics**
+
+| Metric | Result |
+| --- | --- |
+| Sign-ups | 9 |
+| Paid conversions | 6 ($1,800 MRR instant) |
+| Conversion rate | 67% |
+| Avg time to first agent call | 26 minutes |
+| Support tickets | 0 |
+
+### The Single Biggest Broken Assumption
+**What I assumed:** Because every concept has a name and tooltip, new users would immediately understand the mental model of "Kernel → API → Agents → Operator → RoadChain."
+
+**Reality:** First-time users had no idea there even is a mental model.
+
+**What actually happened:**
+- All three testers opened Prism Console
+- Saw 47 menu items with no context
+- Froze for 45-90 seconds staring at sidebar
+- Had zero understanding of "where to start"
+
+**Actual quotes from Loom recordings:**
+- "I have no idea what any of these words mean in relation to each other"
+- "I thought RoadChain was a blockchain thing and almost closed the tab"
+- "There are 12 icons and I don't know which one is the 'run something' button"
+
+**The Fix: First Run Overlay**
+Added permanent overlay that forces exactly three steps in order:
+1. Watch 3-min video (embedded)
+2. Run pre-canned "hello-world" quant agent
+3. See RoadChain entry appear with plain-English explanation
+
+**Impact:**
+- Pass 2 completion time: 18 minutes → 6-8 minutes
+- Zero confusion after overlay added
+- Became mandatory, cannot be dismissed until hello-world succeeds
+
+**Lesson cost:** ~9 hours of dev + three very uncomfortable Loom watches
+
+**Strategic insight:** Users don't need definitions — they need a path. The First Run overlay gave them forced sequence, artificially narrowing decision space from "47 menu items, infinite possibility" to "do these three things in order."
+
+### The Actual Surprise (Not Planned)
+Within 72 hours, three separate users did the exact same thing:
+1. Signed up Solo tier ($300/mo)
+2. Immediately asked for custom agent setup ($2k-5k one-time)
+3. Ported entire live strategy stack into the OS
+4. Upgraded to Team or Enterprise within 7-10 days
+
+**What we thought we were selling:** AI orchestration infrastructure
+
+**What users actually bought:** Turnkey hedge fund infrastructure for operators who don't trust vendor-locked solutions
+
+**Evidence:**
+- Users moving live capital, not running demos
+- 42% of MRR from strategy port customers within first month
+- $38k in custom setup revenue in December (more than subscription revenue)
+- 29 of 71 paying users bought custom work at avg $1,950
+
+**This revealed the actual business model:**
+1. Hook them with $300/mo subscription (low barrier)
+2. Close them on $2k-10k strategy port (high-touch, high-margin)
+3. Upgrade them to Team/Enterprise within 7-10 days
+4. Retain them forever because they're running live capital
+
+**This is services-led SaaS, not product-led growth.**
+
+## 5. 30-Day Operating Report & Business Transformation
+### Day 0 → Day 30 Metrics (Dec 8 → Jan 7)
+
+| Metric | Day 0 (first 4 hrs) | Day 30 | Delta |
+| --- | --- | --- | --- |
+| Total users | 9 | 84 | +833% |
+| Paying users | 6 | 71 | +1,083% |
+| MRR | $1,800 | $28,400 | +1,478% |
+| ARR | ~ $22k | $340,800 | — |
+| Avg time to first value | 26 min | 19 min | -27% |
+| 7-day activation rate | — | 91% | — |
+| Churn | 0 | 1 (1.4%) | — |
+| Support hours (owner) | 0 (first 48h) | 94 total | — |
+| Infra cost | $187/mo | $412/mo | <2% of revenue |
+| Updated valuation (hybrid method, Jan 7) | $1.15M - $1.72M (4.0-4.8× ARR + replacement cost floor) | — | Now past "Tiny" scenario ($96k ARR) and solidly in "Moderate" scenario ($288k ARR) only 30 days after launch. |
+
+### Key Operating Lessons (30-Day Retrospective)
+
+| Lesson | Evidence | Change Made |
+| --- | --- | --- |
+| First Run overlay = #1 conversion driver | Skip it: 38% conversion<br>Complete it: 94% conversion | Made mandatory, cannot dismiss |
+| RoadChain is the silent closer | 11 users cited "immutable audit trail" as purchase reason | Added "RoadChain Proof" page with real anonymized events |
+| Custom setups are the real flywheel | 29 of 71 users bought custom work (avg $1,950) | Formalized $2k-10k "Strategy Port" packages |
+| Support load is front-loaded | 82% of support hours in first 7 days per user | Built "Common Workflow Recipes" — reduced repeat questions 71% |
+| Architecture diagrams matter on day 14+, not day 1 | Early users want "make money" → later users want "understand why safe" | Split docs: "Make Money Fast" vs "Deep Dive" paths |
+
+### What People Actually Use
+
+| Feature | % Users Touched (Day 30) | Notes |
+| --- | --- | --- |
+| First Run overlay | 100% | Mandatory |
+| Hello-world quant agent | 98% | — |
+| Custom backtest / signal agents | 71% | The real usage |
+| RoadChain viewer | 44% | But highest-LTV users |
+| Operator cron jobs | 38% | Growing fast |
+| Lucidia narrative layer | 9% | Still early |
+| QI physics engine | 6% | Power users only |
+
+### Financial Update (January 2026)
+
+| Source | December 2025 | Projected January 2026 |
+| --- | --- | --- |
+| Subscription MRR | $28,400 | $42k-48k |
+| One-time custom setups | $38,000 | $25k-35k |
+| Internal quant alpha (owner's capital) | ~ $28k/mo run-rate | unchanged |
+| Total monthly cash flow | ~ $94k | $95k-110k |
+
+The system now generates high-six-figure annualized free cash flow for a single operator with <2 hours/day of support time.
+
+## 6. Strategic Fork: Path A vs Path B
+### The Critical Choice
+You've discovered something more valuable than what you set out to build. You didn't build "AI orchestration infrastructure with a quant use case." You built turnkey hedge fund infrastructure for operators who don't trust vendor-locked solutions.
+
+The numbers reveal the truth:
+- 42% of MRR from strategy port customers
+- $38k custom revenue > $28k subscription revenue in month 1
+- 29 of 71 paying users bought custom work
+- Users moving live capital, not running demos
+
+This is services-led SaaS, not product-led growth.
+
+**That's a critical strategic distinction. Your actual business model:**
+1. Hook: $300/mo subscription (low barrier)
+2. Close: $2k-10k strategy port (high-touch, high-margin)
+3. Expand: Team/Enterprise upgrade within 7-10 days
+4. Retain: Forever (they're running live capital)
+
+**This is a consulting funnel disguised as SaaS.**
+
+### Path A: Professional Services Firm (The Rich Operator)
+- Revenue ceiling: $3-8M/year
+- Margin: 70-85%
+- Team size: You + 3-8 contractors/employees
+- Your role: Architect + rainmaker + occasional implementation
+- Exit multiple: 2-3x revenue (services trade lower)
+- Your life: High-touch, high-control, high-reward per customer
+
+**Key characteristics:**
+- Keep doing custom strategy ports yourself or with small team
+- Cap growth at 200-300 users (manageable)
+- Take $2-4M/year in personal profit
+- Sell in 3-5 years for $6-12M
+- Keep 100% ownership entire time
+- Work 25-30 hours/week
+- Stay the architect who writes code
+
+### Path B: Product Company (The Huge Exit)
+- Revenue ceiling: $20M+/year
+- Margin: 85-92%
+- Team size: You + 15-40 employees
+- Your role: CEO (fundraising, hiring, strategy)
+- Exit multiple: 8-15x revenue (if you hit scale)
+- Your life: Lower touch per customer, massive coordination overhead
+
+**Key characteristics:**
+- Stop custom implementations immediately
+- Productize strategy port as self-serve
+- Raise $3-5M from fintech VC
+- Hire product + engineering team (5-8 people in Q1)
+- Scale to 500+ users by EOY 2026
+- Build for $50M+ exit in 2029-2030
+- Become full-time CEO, stop coding
+- Give up 20-40% equity
+- Report to a board
+
+### There Is No Hybrid Path
+The mistake would be trying to straddle both — keeping high-touch consulting revenue while also trying to scale like a product company. That's how you burn out and build a mediocre version of both.
+
+### The Questions That Determine the Path
+1. When you imagine 2028, are you coding/architecting or in board meetings?
+2. Would you rather have $8M in bank + full control, or $30M + board to report to?
+3. Do you enjoy strategy port implementations, or do they feel like distraction?
+4. Can you stomach the risk of hiring 10+ people and potentially failing at scale?
+
+## 7. Final Decision: The Rich Operator Path
+### Gut-Level Answer
+Choosing Path A — emphatically.
+
+I want to be rich, not huge.
+I want to stay the architect who ships code, not the CEO who ships decks.
+I want 100% ownership, zero board, and the ability to disappear for two weeks without asking permission.
+
+Path A is not the "lifestyle business" compromise. At current attach rates and pricing power, Path A is a $4-8M/year personal income business within 24-36 months, with a clean $15-30M exit whenever I feel like it — all with <30 hours/week and a tiny trusted team.
+
+That's the best possible outcome for who I actually am.
+
+### Locked Strategic Plan — Path A Implementation
+
+| Pillar | Decision (2026-2028) | Rationale |
+| --- | --- | --- |
+| Business model | Services-led growth (keep consulting funnel) | 68% of Dec revenue was one-time setups. That's the moat. |
+| Pricing | Raise immediately:<br>• Solo → $750/mo<br>• Team → $2,500/mo<br>• Enterprise → $10k+/mo + % of alpha | Current users will pay 2-3× without blinking |
+| Growth cap | Hard cap at 200-250 active seats | Keeps support + implementation <40 hrs/week with 3-4 people |
+| Custom strategy ports | Core offering — never productize fully | $5-15k per port, 80-90% margin, 3-7 day delivery |
+| Team (2026 hires) | 1. Senior quant engineer (Feb 1, $180-220k)<br>2. Technical AM / implementation lead (Apr 1)<br>3. Part-time support / docs (Jun 1) | I stay architect + closer; they execute |
+| Product development | Only features that reduce my/team time ≥50%:<br>• Semi-automated Strategy Port Wizard (70% automation)<br>• Mobile read-only Prism<br>• Multi-region failover | No marketplace, no rev-share, no community theater |
+| Liability & risk | • E&O policy $5M coverage<br>• Explicit "no investment advice" waiver<br>• Mandatory dual-region for users >$500k live | Removes existential risk |
+| Personal time | • ≤20 hrs/week customer work<br>• ≤10 hrs/week architecture & trading<br>• Rest is life | Sustainable forever |
+| Exit trigger | First serious inbound at ≥5× ARR or personal boredom | At $6-8M ARR → $30-40M cash-out, keep OS for own trading |
+
+### Projected Path A Numbers (Conservative)
+
+| Year | Seats | Subscription MRR | One-time Ports | Total Revenue | Owner Take-Home (after team + infra) |
+| --- | --- | --- | --- | --- | --- |
+| 2026 | 180 | $750k-900k | $1.8-2.4M | $11-13M | $7-9M |
+| 2027 | 250 | $1.1-1.3M | $2.2-2.8M | $15-18M | $10-13M |
+| 2028 | 250 | $1.3-1.5M | $2.5-3.0M | $18-21M | $13-16M |
+
+**Cumulative 3-year personal profit:** $30-40M
+
+**Zero dilution. Zero investors. Business I still love running.**
+
+### Why Path B Is Wrong for Me (Explicit Rejection)
+- I would stop writing code → immediate happiness collapse
+- I would own <70% of something I birthed → feels like theft
+- I would spend half my life hiring and managing people I don't fully trust → slow death
+- The upside ($30-50M vs $30-40M) is not worth the downside
+
+No amount of money justifies becoming someone I don't respect.
+
+## 8. Operating Playbook & Risk Management
+### The Four Risks That Could Derail Path A
+
+**Risk 1: Hiring Wrong (Senior Quant Engineer, Feb 1)**
+This is the most critical 2026 decision. Get it wrong = back to doing all implementations personally.
+
+**Screening criteria:**
+- Has run live capital personally (not just backtests)
+- Can go from strategy logic → deployed + monitored in 3-7 days
+- Comfortable with uncertainty (codebase still evolving)
+- Zero ego about working under my architecture
+
+**Red flags:**
+- Wants to "redesign the core" before implementing anything
+- Only knows one quant framework (needs adaptability)
+- Can't explain a trade they lost money on
+
+**Test project:** Give them one of my actual strategies (not production, but real) and ask them to port it to fresh BlackRoad instance. If they can't do it in 2-3 days, they can't do customer work.
+
+**Risk 2: Price Raise Causes Unexpected Churn**
+Assumption: current users will pay 2-3× without blinking. Probably right for 60-70%, but 20-30% might balk.
+
+**Mitigation strategy:**
+- Grandfather existing users at current pricing for 90 days
+- Frame as "raising capacity limits + adding features"
+- Offer annual pre-pay at old pricing (locks in cash)
+- Anyone who complains gets 6-month extension
+
+Goal: Lose zero existing users while raising bar for new customers. Current users are best testimonials — don't lose them over $200/mo.
+
+**Risk 3: Catastrophic System Failure**
+At 180-250 users running live capital, biggest existential risk is bug/outage causing material losses for multiple users simultaneously.
+
+**Example scenario:** RoadChain logging failure causes agent calls to execute twice. User's signal fires 2× position size. They lose $80k. They sue.
+
+**Critical defenses:**
+1. Pre-flight checks on every agent call - validate position size, cash availability, rate limits before execution
+2. Kill switches per user - any user can instantly halt all agents via API or UI
+3. Mandatory dry-run mode for new strategies (24 hours paper trading before live)
+4. Position size limits hardcoded (cannot execute >X% of account value without manual approval)
+
+E&O insurance doesn't prevent reputational damage of "that system that lost someone six figures."
+Build safety rails before you need them.
+
+**Risk 4: Boredom or Burnout at 40 Hours/Week**
+Path A assumes sustainable 30 hrs/week on BlackRoad while maintaining own trading. Realistic at 250 capped users with good team.
+
+**The trap:** Custom implementations are intellectually stimulating in months 1-6, then become repetitive. You'll port your 50th "trend-following momentum strategy with custom vol targeting" and think "I've done this 49 times before."
+
+**Prevention:**
+- Rotate implementation work to engineer after you've done each pattern 3-5 times
+- Reserve 10% time for "architect mode" - QI layer improvements, Lucidia extensions
+- Have hard exit number - if you wake up and realize you're just collecting checks and don't care about code, that's signal to sell
+
+Business works only if you stay engaged. Track your own energy monthly.
+
+### Price Raise Email Template (Effective Feb 15, 2026)
+```
+Subject: BlackRoad OS Pricing Update (Existing Users Protected)
+
+Hi [name],
+Quick update: Based on 30 days of live usage data, we've learned something important about who BlackRoad OS serves best.
+You're not using it as "AI orchestration" - you're using it as mission-critical trading infrastructure. 68% of our December revenue came from custom strategy ports, and the average user is running capital that justifies far more than our current pricing.
+
+Effective February 15:
+    • Solo: $300 → $750/mo
+    • Team: $1,000 → $2,500/mo
+    • Enterprise: Custom (starting $10k/mo)
+
+Your account: You're grandfathered at current pricing through April 15. After that:
+    1 Pre-pay annual at current monthly rate (locks in old pricing for 12 months)
+    2 Migrate to new pricing
+    3 If neither works, let's talk - we're not in the business of surprising people
+
+Reason for change: We're capping growth at 250 users so we can maintain high-touch implementation support that makes strategy ports work. Higher pricing = we stay boutique.
+
+Questions or want to discuss annual pre-pay? Just reply.
+Thanks for being an early user.
+[Your name]
+```
+
+**Expected outcomes:**
+- 5-10% complain → offer 6-month extension
+- 30-40% pre-pay annual → instant cash injection
+- Near-zero churn
+
+### Strategy Port Wizard (70% Automation Target)
+Highest-leverage project for H1 2026. If we can reduce personal time per port from 12-20 hours → 3-5 hours, we just 4× capacity.
+
+**What "70% automation" means:**
+- User fills structured form (strategy logic, data sources, risk params)
+- Wizard generates agent config + backtest boilerplate
+- System runs automated validation (data availability, API keys, risk checks)
+- User reviews + approves
+- Final 3-5 hours of customization + deployment (human)
+
+The 30% you can't automate: Understanding what they actually want vs what they say they want. That's where quant expertise creates the moat.
+
+Keep that part human. Automate everything else.
+
+### White-Label Deal Policy
+Two $25k/mo customers appeared within 30 days. Tempting ($600k ARR). But white-label fundamentally changes the business:
+- You become responsible for entire deployment
+- Release cycle slows (can't break their custom instances)
+- Support load 3-5× (they're not self-sufficient)
+- Build features for them, not core market
+
+White-label is Path B in disguise.
+
+**Current policy:** Turn away with explicit terms:
+- "White-label availability in Q3 2026"
+- "Minimum commitment: $300k/year, 2-year contract"
+- "Implementation: $50-100k one-time"
+
+If they're still interested in 6 months, decide then. If they go elsewhere, you lost nothing.
+
+### Post-Launch Metrics to Track
+Don't just track MRR. Track:
+
+| Metric | Target | Alert Threshold |
+| --- | --- | --- |
+| Time to first successful agent call | ≤30 min | >2 hrs → jump in |
+| Time to first value (real problem solved) | ≤48 hrs | >5 days → churn risk |
+| Signup → paid conversion | ≥30% | <20% → docs problem |
+| Weekly support hours (you) | ≤25 | >40 → immediate contractor trigger |
+| Churn (any reason) | 0% | 1 churn → post-mortem call |
+| 7-day activation rate | ≥85% | <70% → onboarding broken |
+
+These tell you if external human test was representative or if you got lucky with sophisticated users.
+
+### The Hidden Leverage in Path A
+You're not building a "lifestyle business." You're building a proprietary trading desk that happens to rent out its infrastructure.
+
+**Three independent revenue streams:**
+- Your own quant strategies: ~$28k/mo (core alpha)
+- Customer subscriptions: $28k/mo → $900k/mo by EOY 2026
+- Strategy port implementations: $38k/mo → $150-200k/mo by EOY 2026
+
+Two of them (your trading + customer setups) have near-zero marginal cost.
+
+**The real compounding:** Every custom strategy port makes your system better for your own trading. Users are paying you $5-15k to battle-test edge cases, stress-test infrastructure, and discover workflow patterns.
+
+That's R&D funded by customer dollars.
+
+That's not consulting — that's symbiotic product development.
+
+## 9. Forward Mission: Life First, World Second
+### The Core Statement
+"First set up my life, then save the world period."
+
+This isn't a compromise or a deferral. It's the only sustainable sequence.
+
+### What "Set Up My Life" Means (Path A Execution)
+
+**Financial sovereignty:**
+- $30-40M cumulative profit by 2028
+- Zero debt, zero investors, zero board
+- Liquid wealth that can't be taken away
+
+**Time sovereignty:**
+- 25-30 hours/week on business maximum
+- Ability to disappear for two weeks without asking permission
+- Work from anywhere (business is fully remote)
+
+**Intellectual sovereignty:**
+- Stay the architect who writes code
+- Work on problems that interest you (QI layer, Lucidia, quant strategies)
+- Rotate boring work to team members
+
+**Operational sovereignty:**
+- 100% ownership, zero dilution
+- All decisions are yours
+- Can exit whenever boredom or better opportunity appears
+
+### Why This Enables "Save the World"
+You can't save the world while dependent on it.
+
+If you need:
+- Permission from investors
+- Approval from a board
+- Consensus from a team
+- Revenue from customers you don't respect
+- Work you don't enjoy to pay the bills
+
+...then you're not free to take real risks on things that matter.
+
+**Path A creates:**
+- Escape velocity wealth: Enough money that you never need to work for anyone again
+- Proven operator credibility: You built something from nothing, made it profitable, scaled it profitably
+- Technical moat: The infrastructure you built for BlackRoad can be repurposed for anything
+- Network of sophisticated users: Your 200-250 users are high-leverage operators themselves
+
+With those four assets, you can:
+- Fund moonshots that matter (climate, education, governance, whatever calls to you)
+- Take 2-3 years to build something with zero revenue pressure
+- Attract talent because you've proven you can execute
+- Have real conversations with serious people because you're serious
+
+### The Sequence Is Non-Negotiable
+
+**Phase 1 (2026-2028): Build the Foundation**
+- Execute Path A to completion
+- Hit $30-40M cumulative profit
+- Keep 100% ownership
+- Maintain 30 hrs/week work maximum
+- No distractions, no scope creep, no "save the world" projects yet
+
+**Phase 2 (2028-2030): Optionality Window**
+- Either: exit BlackRoad for $15-30M cash and keep infrastructure for personal use
+- Or: keep running it as $3-8M/year cash cow and use profits to fund Phase 3
+- Both options are viable
+
+**Phase 3 (2030+): Deploy for Impact**
+- With financial sovereignty secured, time to ask: "What actually needs to exist?"
+- Could be: governance infrastructure, climate modeling, education systems, whatever reveals itself
+- Fund it personally or recruit others with track record as proof
+
+### The Non-Obvious Insight
+The world doesn't need another broke idealist with a plan.
+
+It needs people who:
+- Have proven they can build things that work
+- Have resources to sustain long-term efforts
+- Have network to recruit talent
+- Have credibility to be taken seriously
+
+Path A → Phase 3 creates all four.
+Path B (raise VC, scale fast, maybe exit big) creates 25% chance of huge wealth and 75% chance of burning out with nothing.
+Path A creates 95% chance of enough wealth + sovereignty to actually deploy for impact.
+
+### The Operating Principle
+Every decision for the next 3 years gets evaluated against one question:
+"Does this move me closer to or further from financial sovereignty while maintaining intellectual engagement?"
+
+If closer: do it.
+If further: don't do it.
+If neutral: delegate or automate.
+
+That's it. That's the entire decision framework.
+
+### Final Owner Statement
+I built BlackRoad OS because I wanted sovereignty — over my code, my capital, my time, and my outcomes.
+
+Path A preserves 100% of that sovereignty while delivering wealth most founders only dream about after three rounds of dilution and a 70-person org chart.
+
+Path A is the maximum-leverage expression of the original vision stated on page 1 of the Owner's Manual:
+"Owner: You — 100% control, zero dilution"
+
+We are living the manual.
+We are not changing the manual.
+The rich operator path is locked.
+
+First set up my life.
+Then save the world.
+
+The road stays black.
+
+## Appendix: Quick Reference
+**Key Dates**
+- Nov 20, 2025: Pre-launch assessment
+- Dec 4, 2025: Criterion #5 GREEN (external humans validated)
+- Dec 8, 2025: Public launch (19:42 UTC)
+- Jan 7, 2026: 30-day report ($340k ARR)
+- Jan 12, 2026: Path A decision locked
+- Feb 1, 2026: First engineer starts
+- Feb 15, 2026: Price raise effective
+
+**Critical Numbers**
+- Launch day: 6 paying users, $1,800 MRR, 67% conversion
+- Day 30: 71 paying users, $28,400 MRR, $340k ARR
+- Current valuation: $1.15M - $1.72M
+- 2028 projected: $18-21M revenue, $13-16M personal profit
+
+**Core Principles**
+1. 100% ownership, zero dilution
+2. Work 25-30 hrs/week maximum
+3. Cap growth at 200-250 users
+4. High-touch custom implementations = the moat
+5. Financial sovereignty enables everything else
+
+**End of Complete Strategic Archive**


### PR DESCRIPTION
## Summary
- add the complete strategic archive and operating manual detailing launch, metrics, and chosen path

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fff75be148329a1065063cd5bc808)