### PR TITLE
Add health-enabled Next.js apps for console web docs

### DIFF
--- a/apps/docs/.eslintrc.json
+++ b/apps/docs/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,7 @@
+# Docs App (monorepo-owned)
+
+- **Canonical path:** `apps/docs`
+- **Mirror:** `BlackRoad-OS/blackroad-os-docs`
+- **Branch:** `main`
+
+Documentation portal for BlackRoad OS. Edits here are mirrored automatically.

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -1,0 +1,14 @@
+:root {
+  color-scheme: dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f1115;
+  color: #f5f6f8;
+}
+
+a {
+  color: inherit;
+}
+
+body {
+  margin: 0;
+}

--- a/apps/docs/app/health/route.ts
+++ b/apps/docs/app/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    service: "blackroad-os-docs",
+    status: "ok"
+  });
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,0 +1,35 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "BlackRoad OS Docs",
+  description: "Documentation for BlackRoad Operating System"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <div style={{ display: "flex", minHeight: "100vh" }}>
+          <aside
+            style={{
+              width: "260px",
+              borderRight: "1px solid #222",
+              padding: "1rem"
+            }}
+          >
+            <h1 style={{ fontSize: "1.1rem", marginBottom: "1rem" }}>
+              BlackRoad OS Docs
+            </h1>
+            <nav style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <a href="/" style={{ textDecoration: "none" }}>Overview</a>
+              <a href="/getting-started" style={{ textDecoration: "none" }}>Getting Started</a>
+              <a href="/health" style={{ textDecoration: "none" }}>Health</a>
+            </nav>
+          </aside>
+          <main style={{ flex: 1, padding: "2rem" }}>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -1,0 +1,11 @@
+export default function Page() {
+  return (
+    <div>
+      <h2>BlackRoad OS – Documentation</h2>
+      <p>
+        This site will contain architecture, API references, and
+        operator playbooks for the BlackRoad Operating System.
+      </p>
+    </div>
+  );
+}

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "blackroad-os-docs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 8080",
+    "build": "next build",
+    "start": "next start -p 8080",
+    "lint": "next lint",
+    "health": "curl -f http://localhost:8080/health || exit 1"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "^15.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/prism-console/.eslintrc.json
+++ b/apps/prism-console/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/prism-console/app/globals.css
+++ b/apps/prism-console/app/globals.css
@@ -1,0 +1,14 @@
+:root {
+  color-scheme: dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f1115;
+  color: #f5f6f8;
+}
+
+a {
+  color: inherit;
+}
+
+body {
+  margin: 0;
+}

--- a/apps/prism-console/app/health/route.ts
+++ b/apps/prism-console/app/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    service: "blackroad-os-prism-console",
+    status: "ok"
+  });
+}

--- a/apps/prism-console/app/layout.tsx
+++ b/apps/prism-console/app/layout.tsx
@@ -1,0 +1,35 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "BlackRoad OS – Prism Console",
+  description: "Operator console for BlackRoad OS"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <div style={{ display: "flex", minHeight: "100vh" }}>
+          <aside
+            style={{
+              width: "240px",
+              borderRight: "1px solid #222",
+              padding: "1rem"
+            }}
+          >
+            <h1 style={{ fontSize: "1.1rem", marginBottom: "1rem" }}>
+              Prism Console
+            </h1>
+            <nav style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <a href="/" style={{ textDecoration: "none" }}>Dashboard</a>
+              <a href="/agents" style={{ textDecoration: "none" }}>Agents</a>
+              <a href="/health" style={{ textDecoration: "none" }}>Health</a>
+            </nav>
+          </aside>
+          <main style={{ flex: 1, padding: "1.5rem" }}>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/prism-console/app/page.tsx
+++ b/apps/prism-console/app/page.tsx
@@ -1,0 +1,13 @@
+export default function Page() {
+  return (
+    <div>
+      <h2>Prism Console</h2>
+      <p>Welcome to the BlackRoad OS operator console.</p>
+      <ul>
+        <li>Monitor services</li>
+        <li>Inspect agents</li>
+        <li>Trigger workflows</li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/prism-console/next-env.d.ts
+++ b/apps/prism-console/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/prism-console/next.config.mjs
+++ b/apps/prism-console/next.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  experimental: {
+    appDir: true
+  },
+  env: {
+    API_URL: process.env.API_URL || "https://api.blackroad.systems"
+  }
+};
+
+export default nextConfig;

--- a/apps/prism-console/package.json
+++ b/apps/prism-console/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "blackroad-os-prism-console",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 8080",
+    "build": "next build",
+    "start": "next start -p 8080",
+    "lint": "next lint",
+    "health": "curl -f http://localhost:8080/health || exit 1"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "^15.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/prism-console/tsconfig.json
+++ b/apps/prism-console/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,14 @@
+:root {
+  color-scheme: dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f1115;
+  color: #f5f6f8;
+}
+
+a {
+  color: inherit;
+}
+
+body {
+  margin: 0;
+}

--- a/apps/web/app/health/route.ts
+++ b/apps/web/app/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    service: "blackroad-os-web",
+    status: "ok"
+  });
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,32 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "BlackRoad OS",
+  description: "The BlackRoad Operating System"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header
+          style={{
+            padding: "1rem 2rem",
+            borderBottom: "1px solid #222",
+            display: "flex",
+            justifyContent: "space-between"
+          }}
+        >
+          <div>BlackRoad OS</div>
+          <nav style={{ display: "flex", gap: "1rem" }}>
+            <a href="/" style={{ textDecoration: "none" }}>Home</a>
+            <a href="/docs" style={{ textDecoration: "none" }}>Docs</a>
+            <a href="/health" style={{ textDecoration: "none" }}>Health</a>
+          </nav>
+        </header>
+        <main style={{ padding: "2rem" }}>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,12 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>BlackRoad Operating System</h1>
+      <p>
+        A multi-service, agent-native OS for orchestrating AI, compute,
+        and compliance.
+      </p>
+      <p>Deployed on Railway. Fronted by Cloudflare. Driven by you.</p>
+    </div>
+  );
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "blackroad-os-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 8080",
+    "build": "next build",
+    "start": "next start -p 8080",
+    "lint": "next lint",
+    "health": "curl -f http://localhost:8080/health || exit 1"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "^15.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js app skeletons for Prism Console, Web, and Docs with app directory layouts
- configure scripts, standalone output, and shared styling for consistent dark theme
- expose /health API routes and metadata for Railway health checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920035fc1408329b1fba39f10830b2b)