### PR TITLE
Add OS services catalog

### DIFF
--- a/services/os-services.json
+++ b/services/os-services.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "core",
+    "name": "BlackRoad OS Core",
+    "kind": "backend",
+    "repo": "https://github.com/BlackRoad-OS/blackroad-os-core",
+    "healthUrl": "https://core.blackroad.systems/health"
+  },
+  {
+    "id": "operator",
+    "name": "BlackRoad OS Operator",
+    "kind": "backend",
+    "repo": "https://github.com/BlackRoad-OS/blackroad-os-operator",
+    "healthUrl": "https://operator.blackroad.systems/health"
+  },
+  {
+    "id": "web",
+    "name": "BlackRoad OS Web",
+    "kind": "frontend",
+    "repo": "https://github.com/BlackRoad-OS/blackroad-os-web",
+    "healthUrl": "https://blackroad.systems/api/health"
+  },
+  {
+    "id": "prism-console",
+    "name": "Prism Console",
+    "kind": "frontend",
+    "repo": "https://github.com/BlackRoad-OS/blackroad-os-prism-console",
+    "healthUrl": "https://console.blackroad.systems/api/health"
+  },
+  {
+    "id": "docs",
+    "name": "BlackRoad OS Docs",
+    "kind": "frontend",
+    "repo": "https://github.com/BlackRoad-OS/blackroad-os-docs",
+    "healthUrl": "https://docs.blackroad.systems/api/health"
+  }
+]

--- a/services/types.ts
+++ b/services/types.ts
@@ -1,0 +1,11 @@
+export type ServiceKind = "backend" | "frontend";
+
+export interface OsService {
+  id: string;
+  name: string;
+  kind: ServiceKind;
+  repo: string;
+  healthUrl: string;
+}
+
+export type OsServiceCatalog = OsService[];


### PR DESCRIPTION
## Summary
- add a declarative os-services.json catalog listing the BlackRoad OS services and health endpoints
- provide TypeScript types describing the service catalog entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920b8e6333c8329b00cb69f4c5ec76a)