### PR TITLE
Consolidate version endpoint and system uptime

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,9 +4,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from contextlib import asynccontextmanager
+import os
+import platform
 import time
 from datetime import datetime, timezone
-import os
 
 from app.config import settings
 from app.database import async_engine, Base
@@ -242,29 +243,18 @@ async def health_check():
 
 
 @app.get("/version")
-async def version():
-    """Service version endpoint"""
+async def version_info():
+    """Version information endpoint"""
+
+    now = datetime.now(timezone.utc)
+
     return {
         "service": "core-api",
         "version": settings.APP_VERSION,
         "environment": settings.ENVIRONMENT,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-
-
-# Version info
-@app.get("/version")
-async def version_info():
-    """Version information endpoint"""
-    import platform
-    from datetime import datetime
-
-    return {
-        "service": "blackroad-core",
-        "version": settings.APP_VERSION,
-        "environment": settings.ENVIRONMENT,
-        "commit": os.getenv("GIT_COMMIT", "unknown"),
-        "built_at": os.getenv("BUILD_TIMESTAMP", datetime.utcnow().isoformat()),
+        "timestamp": now.isoformat(),
+        "commit": os.getenv("GIT_COMMIT", os.getenv("GIT_SHA", "unknown")),
+        "built_at": os.getenv("BUILD_TIMESTAMP", now.isoformat()),
         "python_version": platform.python_version(),
         "platform": platform.system(),
     }

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -1,14 +1,15 @@
 """System endpoints for core OS operations"""
+import os
+from datetime import UTC, datetime, timezone
+
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
-from datetime import datetime, timezone
-from datetime import UTC, datetime
-import os
 
 from app.config import settings
 from app.database import get_db
 
 router = APIRouter(prefix="/api/system", tags=["system"])
+START_TIME = datetime.now(UTC)
 
 
 @router.get("/version")
@@ -23,8 +24,7 @@ async def get_version():
 
     return {
         "version": settings.APP_VERSION,
-        "build_time": datetime.now(timezone.utc).isoformat(),
-        "build_time": datetime.now(UTC).isoformat(),
+        "build_time": os.environ.get("BUILD_TIMESTAMP", START_TIME.isoformat()),
         "env": settings.ENVIRONMENT,
         "git_sha": git_sha[:8] if len(git_sha) > 8 else git_sha,
         "app_name": settings.APP_NAME,
@@ -72,9 +72,11 @@ async def get_os_state(db: AsyncSession = Depends(get_db)):
     - System resources
     """
     # TODO: Integrate with core_os module when implemented
+    uptime_seconds = int((datetime.now(UTC) - START_TIME).total_seconds())
+
     return {
         "status": "ok",
-        "uptime_seconds": 0,  # TODO: Track actual uptime
+        "uptime_seconds": uptime_seconds,
         "active_windows": [],
         "running_apps": [],
         "system_resources": {


### PR DESCRIPTION
## Summary
- consolidate the duplicated /version route into a single response that includes commit, build, and runtime metadata
- initialize system router startup time and use it for build_time and uptime reporting

## Testing
- python -m compileall backend/app/routers/system.py backend/app/main.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a6e7351f0832981b0ca555129688c)